### PR TITLE
Migrate dashboard.tsx from Dexie to Supabase repositories (#55)

### DIFF
--- a/src/modules/ui/components/dashboard.tsx
+++ b/src/modules/ui/components/dashboard.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import { db } from '@storage/database';
+import {
+  getPracticeSessionRepository,
+  getTopicRepository,
+  getSpacedRepetitionRepository,
+} from '@storage/factory';
 import type { PracticeSession } from '@core/types/services';
 import { StatCard } from './common/StatCard';
 import { Card } from './common/Card';
@@ -48,15 +52,18 @@ export function Dashboard({ onClose }: DashboardProps) {
   async function loadDashboardStats() {
     try {
       // Load all sessions
-      const allSessions = await db.practiceSessions.toArray();
+      const sessionRepo = getPracticeSessionRepository();
+      const allSessions = await sessionRepo.getAll();
       const completedSessions = allSessions.filter((s) => s.execution.status === 'completed');
 
       // Load topics for names
-      const topics = await db.topics.toArray();
+      const topicRepo = getTopicRepository();
+      const topics = await topicRepo.getAll();
       const topicMap = new Map(topics.map((t) => [t.id, t]));
 
       // Load spaced repetition items for mastery levels
-      const srItems = await db.spacedRepetition.toArray();
+      const spacedRepRepo = getSpacedRepetitionRepository();
+      const srItems = await spacedRepRepo.getAll();
 
       // Calculate overall stats
       const totalQuestions = completedSessions.reduce(


### PR DESCRIPTION
## Summary
Completes the migration of `dashboard.tsx` from Dexie/IndexedDB to Supabase repositories, removing all local database dependencies from the dashboard component.

## Changes Made

### 🔄 Repository Integration
- Replaced Dexie database import with Supabase repository factory
- Imports: `getPracticeSessionRepository`, `getTopicRepository`, `getSpacedRepetitionRepository`
- All data access now goes through repository pattern

### 📊 Data Access Pattern Changes
| Before (Dexie) | After (Supabase Repository) |
|----------------|----------------------------|
| `db.practiceSessions.toArray()` | `sessionRepo.getAll()` |
| `db.topics.toArray()` | `topicRepo.getAll()` |
| `db.spacedRepetition.toArray()` | `spacedRepRepo.getAll()` |

### ✅ Functionality Preserved
All dashboard features remain unchanged:
- ✅ Dashboard statistics calculations (sessions, accuracy, study time)
- ✅ Topic progress tracking with accuracy percentages  
- ✅ Recent sessions display (last 5 sessions)
- ✅ Mastery levels calculation (mastered, learning, new)
- ✅ Upcoming reviews count

## Code Quality
- ✅ No TypeScript errors
- ✅ HMR updated successfully  
- ✅ All repository methods exist and are compatible
- ✅ Maintains same data structure and filtering logic

## Testing
- ✅ Component compiles without errors
- ✅ Repository methods verified to exist
- ✅ Data transformations remain identical

## Related Issues
- Closes #55
- Part of Epic #60 (Supabase Migration Cleanup)
- Follows pattern established in PR #61 (main.tsx migration)

## Next Steps
After this PR is merged:
- #56: Migrate `practice-session.tsx` from Dexie to Supabase
- #57: Remove legacy Dexie files and dependencies