### PR TITLE
Migrate practice-session.tsx from Dexie to Supabase repositories (#56)

### DIFF
--- a/src/modules/ui/components/practice-session.tsx
+++ b/src/modules/ui/components/practice-session.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import type { Task, PracticeSession, ClozeDeletionContent, TrueFalseContent, OrderingContent, MatchingContent, MultipleSelectContent, SliderContent, WordScrambleContent, FlashcardContent, TextInputContent } from '@core/types/services';
-import { db } from '@storage/database';
 import { PracticeSessionService } from '@core/services/practice-session-service';
 import { SpacedRepetitionService } from '@core/services/spaced-repetition-service';
 import {
@@ -222,7 +221,8 @@ export function PracticeSession({ topicId, learningPathIds, targetCount = 10, in
     await spacedRepService.recordAnswer(currentTask.id, correct, grade);
 
     // Update session state
-    const updatedSession = await db.practiceSessions.get(session.id);
+    const sessionRepo = getPracticeSessionRepository();
+    const updatedSession = await sessionRepo.getById(session.id);
     if (updatedSession) {
       setSession(updatedSession);
     }
@@ -1407,7 +1407,8 @@ export function PracticeSession({ topicId, learningPathIds, targetCount = 10, in
     const taskId = session.execution.taskIds[currentTaskIndex];
     if (!taskId) return;
 
-    const task = await db.tasks.get(taskId);
+    const taskRepo = getTaskRepository();
+    const task = await taskRepo.getById(taskId);
     if (!task) return;
 
     setCurrentTask(task);
@@ -1425,7 +1426,7 @@ export function PracticeSession({ topicId, learningPathIds, targetCount = 10, in
     if (nextTaskIndex < session.execution.taskIds.length) {
       const nextTaskId = session.execution.taskIds[nextTaskIndex];
       if (nextTaskId) {
-        db.tasks.get(nextTaskId).then((nextTask) => {
+        taskRepo.getById(nextTaskId).then((nextTask) => {
           if (nextTask && nextTask.audioUrl) {
             preloadNext(nextTask);
           }


### PR DESCRIPTION
## Summary
Completes the migration of `practice-session.tsx` from Dexie/IndexedDB to Supabase repositories, removing the last direct Dexie usage from active UI components.

## Changes Made

### 🔄 Repository Integration
- Removed Dexie database import: `import { db } from '@storage/database'`
- Repository factory imports already existed (added in previous work)
- All data access now goes through repository pattern

### 📊 Data Access Pattern Changes
| Before (Dexie) | After (Supabase Repository) |
|----------------|----------------------------|
| `db.practiceSessions.get(id)` | `sessionRepo.getById(id)` |
| `db.tasks.get(id)` | `taskRepo.getById(id)` |

### 🎯 Specific Changes
1. **Session State Update** (Line 224-225)
   - After recording an answer, session state is refreshed
   - Changed from `db.practiceSessions.get()` to `sessionRepo.getById()`

2. **Current Task Loading** (Line 1410-1411)
   - Loads the current task for display
   - Changed from `db.tasks.get()` to `taskRepo.getById()`

3. **Audio Preloading** (Line 1429)
   - Preloads next task's audio for better UX
   - Changed from `db.tasks.get()` to `taskRepo.getById()`

### ✅ Functionality Preserved
All practice session features work identically:
- ✅ Session state management and progress tracking
- ✅ Task loading and progression through questions
- ✅ Audio preloading for smoother transitions
- ✅ Answer recording and spaced repetition updates

## Code Quality
- ✅ No TypeScript errors
- ✅ All repository methods exist and tested
- ✅ Data flow logic unchanged
- ✅ Minimal code changes (only 3 call sites updated)

## Testing
- ✅ Component compiles successfully
- ✅ Repository getById() methods verified
- ✅ Logic flow remains identical

## Milestone Achievement
This PR completes **Phase 1** of the Supabase migration cleanup:
- ✅ #54: main.tsx migrated
- ✅ #55: dashboard.tsx migrated  
- ✅ #56: practice-session.tsx migrated ← **This PR**

All active UI components now use Supabase repositories exclusively!

## Related Issues
- Closes #56
- Part of Epic #60 (Supabase Migration Cleanup)
- Follows pattern from PR #61 and PR #62

## Next Steps - Phase 2
After this PR merges, we can proceed with cleanup:
- #57: Remove legacy Dexie files (`database.ts`, `repositories-simple.ts`, `seed-data.ts`)
- #57: Remove Dexie dependencies from package.json
- #58: Update storage adapter contract tests