### PR TITLE
fix: remove '(Spanisch)' from audio auto-play setting label

### DIFF
--- a/src/modules/ui/components/settings/SettingsPage.tsx
+++ b/src/modules/ui/components/settings/SettingsPage.tsx
@@ -298,10 +298,10 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
               checked={settings.audio.autoPlayEnabled}
               onChange={(event) => handleAudioUpdate({ autoPlayEnabled: event.target.checked })}
             />
-            Audio automatisch abspielen (Spanisch)
+            Audio automatisch abspielen
           </label>
           <p className={styles.settingDescription}>
-            Steuert, ob Vokabelkarten automatisch die spanische Aussprache wiedergeben.
+            Steuert, ob Vokabelkarten automatisch die Aussprache wiedergeben.
           </p>
         </div>
       ),


### PR DESCRIPTION
## Summary
- Remove language-specific "(Spanisch)" suffix from the audio auto-play setting label
- Update description text to be language-agnostic

Fixes #137

## Changes
- Label: "Audio automatisch abspielen (Spanisch)" → "Audio automatisch abspielen"
- Description: "...die spanische Aussprache wiedergeben" → "...die Aussprache wiedergeben"

## Test plan
- [ ] Navigate to Settings page
- [ ] Verify audio setting label shows "Audio automatisch abspielen" without "(Spanisch)"
- [ ] Verify description is now language-agnostic
- [ ] Verify toggle functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)