### PR TITLE
chore: exclude storybook files from test coverage metrics

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         '**/dist/',
         '**/coverage/',
         '**/.{idea,git,cache,output,temp}/',
+        '**/*.stories.{ts,tsx}',
       ],
       include: ['src/**/*.{ts,tsx}'],
       all: true,


### PR DESCRIPTION
## Summary

Closes #180

- Add `**/*.stories.{ts,tsx}` to vitest coverage exclude list
- 33+ story files no longer artificially lower coverage percentage
- Coverage metrics now reflect actual application code only

## Changes

- Updated `vitest.config.ts` coverage exclude patterns

## Verification

- Ran `npm run test:coverage` - no story files appear in coverage report
- All tests pass
- Lint and type-check pass

## Test plan

- [x] Run `npm run test:coverage` and verify no `.stories.tsx` files in output
- [x] Confirm all existing tests still pass
- [x] Verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)