### PR TITLE
test: add E2E tests for flashcard auto-advance (#161)

### DIFF
--- a/tests/e2e/flashcard-auto-advance.spec.ts
+++ b/tests/e2e/flashcard-auto-advance.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { login } from './auth.setup';
 
 /**
@@ -13,7 +13,7 @@ import { login } from './auth.setup';
 /**
  * Helper to navigate to Spanish flashcard learning path and start session
  */
-async function startFlashcardSession(page: import('@playwright/test').Page) {
+async function startFlashcardSession(page: Page) {
   // Click on Spanisch topic
   await page.getByRole('button', { name: /Spanisch/i }).click();
   await page.waitForSelector('text=Vokabeltest - Karteikarten', { timeout: 10000 });


### PR DESCRIPTION
## Summary

This PR adds E2E tests to prevent regression of the flashcard auto-advance bug (issue #152, fixed in PR #156).

**Tests Added:**
- Reveal button works before self-assessment
- Clicking "Gewusst" advances to next task
- Clicking "Nicht gewusst" advances to next task
- Multiple flashcards can be completed in sequence

## Test Details

Uses the Spanish flashcard learning path (`vokabeltest-karteikarten`) which contains 98 flashcard tasks.

**Test File:** `tests/e2e/flashcard-auto-advance.spec.ts`

## Related Issues

Closes #161
Related to #152 (bug fix) and PR #156 (fix implementation)

## Test plan

- [x] Linting passes
- [x] Type check passes
- [x] Unit tests pass
- [ ] E2E tests pass (tests disabled in CI per issue #49)

Note: E2E tests are currently disabled in CI (issue #49). The tests follow existing patterns and will be validated when E2E testing is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)