### PR TITLE
fix: suppress console warnings for tasks without audio URLs (#169)

### DIFF
--- a/src/modules/ui/components/practice/PracticeSessionContainer.tsx
+++ b/src/modules/ui/components/practice/PracticeSessionContainer.tsx
@@ -119,10 +119,12 @@ export function PracticeSessionContainer({
       setAudioConfig(config);
     });
 
-    // Load audio for the task
-    loadAudio(currentTask, audioSettings, false).catch((error) => {
-      console.warn('Failed to load audio:', error);
-    });
+    // Load audio for the task (only if task has audio URL)
+    if (currentTask.audioUrl) {
+      loadAudio(currentTask, audioSettings, false).catch((error) => {
+        console.warn('Failed to load audio:', error);
+      });
+    }
   }, [currentTask, audioSettings, loadAudio]);
 
   // Get current task hook based on type


### PR DESCRIPTION
## Summary
- Adds guard to check if task has `audioUrl` before calling `loadAudio()` in `PracticeSessionContainer.tsx`
- Prevents unnecessary console warnings when tasks don't have audio URLs configured

## Changes
- Modified `useEffect` in `PracticeSessionContainer.tsx` to only call `loadAudio()` when `currentTask.audioUrl` exists

## Test plan
- [x] All existing tests pass (2145 tests)
- [x] Practice sessions with audio tasks work normally
- [x] Practice sessions without audio tasks no longer log console warnings

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)