### PR TITLE
fix: display correct version from package.json in Settings (#151)

### DIFF
--- a/src/modules/ui/components/settings/SettingsPage.tsx
+++ b/src/modules/ui/components/settings/SettingsPage.tsx
@@ -399,7 +399,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
       content: (
         <div className={styles.settingGroup}>
           <div className={styles.infoCard}>
-            <div>Version: 1.0.0</div>
+            <div>Version: {import.meta.env.VITE_APP_VERSION ?? 'unknown'}</div>
             <div>Letzte Aktualisierung: {new Intl.DateTimeFormat('de-DE').format(new Date())}</div>
           </div>
           <div className={styles.buttonRow}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,13 @@ import { VitePWA } from 'vite-plugin-pwa';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Read version from package.json at build time
+const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
+const appVersion = packageJson.version;
 
 /**
  * Vite plugin to inject CSP meta tag with environment-specific Supabase URL
@@ -64,6 +69,7 @@ export default defineConfig(({ mode }) => {
   define: {
     'import.meta.env.VITE_DB_NAME': JSON.stringify(env.VITE_DB_NAME || 'mindforge-academy'),
     'import.meta.env.VITE_ENV': JSON.stringify(env.VITE_ENV || 'production'),
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
   },
   plugins: [
     cspPlugin(supabaseUrl, isDevelopment),


### PR DESCRIPTION
## Summary

- Fixes the Settings page showing hardcoded "1.0.0" instead of the actual package version
- Reads version from `package.json` at build time via Vite's `define` option
- Injects version as `VITE_APP_VERSION` environment variable
- Uses the injected version in SettingsPage with fallback for robustness

## Changes

- **vite.config.ts**: Added `readFileSync` import, reads `package.json` version at build time, injects `VITE_APP_VERSION`
- **SettingsPage.tsx**: Replaced hardcoded "1.0.0" with `import.meta.env.VITE_APP_VERSION ?? 'unknown'`

## Test Plan

- [x] Build passes with `npm run build`
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 2475 unit tests pass
- [x] Version is correctly injected at build time (verified in build output)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)