### PR TITLE
feat: remove difficulty and time estimate from learning path cards

### DIFF
--- a/src/modules/ui/components/LearningPathCard.module.css
+++ b/src/modules/ui/components/LearningPathCard.module.css
@@ -38,14 +38,6 @@
   margin-bottom: var(--spacing-sm);
 }
 
-.learning-path-card__difficulty {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--difficulty-color);
-}
-
 .learning-path-card__completed-badge {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
@@ -83,8 +75,7 @@
   margin-bottom: var(--spacing-md);
 }
 
-.learning-path-card__task-count,
-.learning-path-card__time {
+.learning-path-card__task-count {
   font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
 }

--- a/src/modules/ui/components/LearningPathCard.tsx
+++ b/src/modules/ui/components/LearningPathCard.tsx
@@ -55,16 +55,10 @@ export interface LearningPathCardProps {
   className?: string;
 }
 
-const DIFFICULTY_CONFIG = {
-  easy: { label: 'Leicht', color: 'var(--color-success)', emoji: '🟢' },
-  medium: { label: 'Mittel', color: 'var(--color-warning)', emoji: '🟡' },
-  hard: { label: 'Schwer', color: 'var(--color-error)', emoji: '🔴' },
-};
-
 /**
  * Learning Path Card Component
  *
- * Displays a learning path with title, description, difficulty,
+ * Displays a learning path with title, description,
  * task count, and optional progress indicator.
  *
  * @example
@@ -89,7 +83,6 @@ export function LearningPathCard({
   const shouldReduceMotion = useReducedMotion();
   const skipAnimation = !animate || shouldReduceMotion;
 
-  const difficulty = DIFFICULTY_CONFIG[learningPath.difficulty];
   const hasProgress = progress && progress.completedTasks > 0;
   const completionPercentage = taskCount > 0 ? (progress?.completedTasks ?? 0) / taskCount * 100 : 0;
   const isCompleted = progress && progress.completedTasks >= taskCount;
@@ -120,7 +113,7 @@ export function LearningPathCard({
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label={`${learningPath.title} - ${difficulty.label} - ${taskCount} Aufgaben`}
+      aria-label={`${learningPath.title} - ${taskCount} Aufgaben`}
       initial={skipAnimation ? {} : { opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={
@@ -131,20 +124,14 @@ export function LearningPathCard({
       whileHover={skipAnimation ? {} : { scale: 1.02 }}
       whileTap={skipAnimation ? {} : { scale: 0.98 }}
     >
-      {/* Header with difficulty badge */}
-      <div className={styles['learning-path-card__header']}>
-        <span
-          className={styles['learning-path-card__difficulty']}
-          style={{ '--difficulty-color': difficulty.color } as React.CSSProperties}
-        >
-          {difficulty.emoji} {difficulty.label}
-        </span>
-        {isCompleted && (
+      {/* Header with completion badge */}
+      {isCompleted && (
+        <div className={styles['learning-path-card__header']}>
           <span className={styles['learning-path-card__completed-badge']}>
             ✓ Abgeschlossen
           </span>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Title */}
       <h3 className={styles['learning-path-card__title']}>{learningPath.title}</h3>
@@ -157,11 +144,6 @@ export function LearningPathCard({
         <span className={styles['learning-path-card__task-count']}>
           📝 {taskCount} Aufgaben
         </span>
-        {learningPath.estimatedTime > 0 && (
-          <span className={styles['learning-path-card__time']}>
-            ⏱️ ~{learningPath.estimatedTime} Min.
-          </span>
-        )}
       </div>
 
       {/* Progress bar (only if user has started) */}

--- a/tests/unit/ui/components/LearningPathCard.test.tsx
+++ b/tests/unit/ui/components/LearningPathCard.test.tsx
@@ -59,44 +59,6 @@ describe('LearningPathCard', () => {
       expect(screen.getByText('📝 15 Aufgaben')).toBeInTheDocument();
     });
 
-    it('displays estimated time when provided', () => {
-      render(
-        <LearningPathCard learningPath={mockLearningPath} taskCount={10} onSelect={mockOnSelect} />
-      );
-
-      expect(screen.getByText('⏱️ ~30 Min.')).toBeInTheDocument();
-    });
-
-    it('does not display estimated time when zero', () => {
-      const pathWithoutTime = { ...mockLearningPath, estimatedTime: 0 };
-      render(<LearningPathCard learningPath={pathWithoutTime} taskCount={10} onSelect={mockOnSelect} />);
-
-      expect(screen.queryByText(/Min\./)).not.toBeInTheDocument();
-    });
-  });
-
-  // Difficulty display tests
-  describe('Difficulty Display', () => {
-    it('displays easy difficulty', () => {
-      const easyPath = { ...mockLearningPath, difficulty: 'easy' as const };
-      render(<LearningPathCard learningPath={easyPath} taskCount={10} onSelect={mockOnSelect} />);
-
-      expect(screen.getByText(/🟢 Leicht/)).toBeInTheDocument();
-    });
-
-    it('displays medium difficulty', () => {
-      const mediumPath = { ...mockLearningPath, difficulty: 'medium' as const };
-      render(<LearningPathCard learningPath={mediumPath} taskCount={10} onSelect={mockOnSelect} />);
-
-      expect(screen.getByText(/🟡 Mittel/)).toBeInTheDocument();
-    });
-
-    it('displays hard difficulty', () => {
-      const hardPath = { ...mockLearningPath, difficulty: 'hard' as const };
-      render(<LearningPathCard learningPath={hardPath} taskCount={10} onSelect={mockOnSelect} />);
-
-      expect(screen.getByText(/🔴 Schwer/)).toBeInTheDocument();
-    });
   });
 
   // Progress display tests
@@ -325,15 +287,7 @@ describe('LearningPathCard', () => {
       );
 
       const card = screen.getByRole('button');
-      expect(card).toHaveAttribute('aria-label', 'Basic Algebra - Leicht - 10 Aufgaben');
-    });
-
-    it('has correct aria-label for different difficulties', () => {
-      const hardPath = { ...mockLearningPath, difficulty: 'hard' as const };
-      render(<LearningPathCard learningPath={hardPath} taskCount={15} onSelect={mockOnSelect} />);
-
-      const card = screen.getByRole('button');
-      expect(card).toHaveAttribute('aria-label', 'Basic Algebra - Schwer - 15 Aufgaben');
+      expect(card).toHaveAttribute('aria-label', 'Basic Algebra - 10 Aufgaben');
     });
 
     it('has no WCAG violations', async () => {
@@ -372,16 +326,16 @@ describe('LearningPathCard', () => {
       expect(results).toHaveNoViolations();
     });
 
-    it('has no WCAG violations with all difficulties', async () => {
-      const easyPath = { ...mockLearningPath, difficulty: 'easy' as const };
-      const mediumPath = { ...mockLearningPath, difficulty: 'medium' as const, id: 'path-2' };
-      const hardPath = { ...mockLearningPath, difficulty: 'hard' as const, id: 'path-3' };
+    it('has no WCAG violations with multiple cards', async () => {
+      const path1 = { ...mockLearningPath, id: 'path-1' };
+      const path2 = { ...mockLearningPath, id: 'path-2', title: 'Geometry Basics' };
+      const path3 = { ...mockLearningPath, id: 'path-3', title: 'Calculus Intro' };
 
       const { container } = render(
         <div>
-          <LearningPathCard learningPath={easyPath} taskCount={10} onSelect={mockOnSelect} />
-          <LearningPathCard learningPath={mediumPath} taskCount={15} onSelect={mockOnSelect} />
-          <LearningPathCard learningPath={hardPath} taskCount={20} onSelect={mockOnSelect} />
+          <LearningPathCard learningPath={path1} taskCount={10} onSelect={mockOnSelect} />
+          <LearningPathCard learningPath={path2} taskCount={15} onSelect={mockOnSelect} />
+          <LearningPathCard learningPath={path3} taskCount={20} onSelect={mockOnSelect} />
         </div>
       );
       const results = await axe(container);


### PR DESCRIPTION
## Summary
Removes difficulty indicator (Leicht/Mittel/Schwer) and time estimate (~X Min.) from learning path cards as requested in #218.

## Changes Made
- ✅ Removed difficulty badge from LearningPathCard header
- ✅ Removed time estimate display from meta section
- ✅ Removed DIFFICULTY_CONFIG constant (no longer needed)
- ✅ Updated aria-label to exclude difficulty information
- ✅ Updated all tests to remove difficulty and time estimate assertions
- ✅ Updated accessibility tests to test multiple cards instead of difficulty variations

## Testing
- ✅ Build succeeds (`npm run build`)
- ✅ All 3,423 tests pass (`npm test`)
- ✅ No linting errors (`npm run lint`)
- ✅ LearningPathCard tests (33 tests) all pass

## Acceptance Criteria from #218
- [x] Difficulty badge/indicator is hidden in Lernpfade overview
- [x] Time estimate is hidden in Lernpfade overview  
- [x] No visual regressions in the remaining UI elements
- [x] Tests updated if necessary

## Files Changed
- `src/modules/ui/components/LearningPathCard.tsx` - Removed difficulty and time displays
- `tests/unit/ui/components/LearningPathCard.test.tsx` - Updated tests

Closes #218